### PR TITLE
fix ci: no get-changed-files id

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           python-version: 3.10.2
       - name: get changed files
         uses: tj-actions/changed-files@v21
+        id: changed-files
         with:
           since_last_remote_commit: true
       - name: obs2mk source files
@@ -38,6 +39,7 @@ jobs:
           git pull
           git config --global user.name 'github-actions'
           git config --global user.email 'github-actions@users.noreply.github.com'
+          rm -rf ./site/
           git add . 
           fileList=$(git status --porcelain | tr -d '\n' | tr -d 'M' |tr -d '??')
           git commit -m "🏓 Publishing from ObsidianMD" -m "${fileList}"


### PR DESCRIPTION
- `${{ steps.changed-files.outputs.all_changed_files }}` didn't get anything if step `get-changed-files` without a id.
- Static content has been committed to the gh-pages branch, no need to continue committing in `./site` of main branch.
